### PR TITLE
Fix deprecation notice

### DIFF
--- a/jchart/templatetags/jchart.py
+++ b/jchart/templatetags/jchart.py
@@ -2,7 +2,10 @@ import uuid
 
 from django import template
 from django.template.loader import render_to_string
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # maintain backwards compatibility for Django < 1.10
 
 from .. import Chart
 

--- a/jchart/templatetags/jchart.py
+++ b/jchart/templatetags/jchart.py
@@ -2,7 +2,7 @@ import uuid
 
 from django import template
 from django.template.loader import render_to_string
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .. import Chart
 


### PR DESCRIPTION
```
/.../jchart/templatetags/jchart.py:5: RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
  from django.core.urlresolvers import reverse
```