### PR TITLE
Move the sizing to method recommended by chart.js

### DIFF
--- a/jchart/templates/charting/async/html.html
+++ b/jchart/templates/charting/async/html.html
@@ -1,2 +1,3 @@
-<canvas class="chart" id="{{ html_id }}" height="{{ height }}">
-</canvas>
+<div class="chart-container" style="position: relative; {% if chart.height %}height: {{ chart.height }}px;{% endif %} {% if chart.width %}width: {{ chart.width }}px{% endif %}">
+  <canvas class="chart" id="{{ html_id }}"></canvas>
+</div>

--- a/jchart/templates/charting/html.html
+++ b/jchart/templates/charting/html.html
@@ -1,2 +1,3 @@
-<canvas class="chart" id="{{ html_id }}" {% if chart.height %}height="{{ chart.height }}"{% endif %} {% if chart.width %}width="{{ chart.width }}"{% endif %}>
-</canvas>
+<div class="chart-container" style="position: relative; {% if chart.height %}height: {{ chart.height }}px;{% endif %} {% if chart.width %}width: {{ chart.width }}px{% endif %}">
+  <canvas class="chart" id="{{ html_id }}"></canvas>
+</div>

--- a/jchart/tests.py
+++ b/jchart/tests.py
@@ -307,16 +307,16 @@ class ChartTestCase(TestCase):
         self.assertEquals(line_chart.width, 1000)
         self.assertEquals(line_chart.height, 500)
 
-        self.assertIn('height="500"', line_chart.as_html())
-        self.assertIn('width="1000"', line_chart.as_html())
+        self.assertIn('height: 500px', line_chart.as_html())
+        self.assertIn('width: 1000px', line_chart.as_html())
 
     def test_chart_no_dimension(self):
         line_chart = LineChart()
         self.assertEquals(line_chart.width, None)
         self.assertEquals(line_chart.height, None)
 
-        self.assertNotIn('height="', line_chart.as_html())
-        self.assertNotIn('width="', line_chart.as_html())
+        self.assertNotIn('height:', line_chart.as_html())
+        self.assertNotIn('width:', line_chart.as_html())
 
     def test_chart_html_id(self):
         line_chart = LineChart(html_id='test-id')


### PR DESCRIPTION
Add a chart-container wrapper div and move the sizing styling to be
applied to this as recommended by the chart.js docs: http://www.chartjs.org/docs/latest/general/responsive.html#important-note

This means you can also set a height for the charts by adding css rules
that apply to the chart container combined by setting
`maintainAspectRatio` to `False`

For example:
Adding `options = {'maintainAspectRatio': False}` to your Chart subclass
and adding the below css rule.
```css
.chart-container {
    height: 300px;  /* this can also be in other units such as viewport units*/
}
```


Regarding the code itself:
- I can’t see where the async templates are used - It looks to me like they’re not but I changed the async template to be in line with the other template anyway.
- It is hard to test that it has the expected effect (essentially none for existing users). Let me know if you can think of a way to test it @matthisk 
- This potentially has implications for the check that asserts that `responsive=False` before you can set a `width` or `height` as it is also fine if you have `maintainAspectRatio=False`.