### PR TITLE
Added support for 'hidden' config properties to hide DataSet by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Version 0.5.1
+
+* Added support for 'hidden' config properties to hide `DataSet` by default
+
 ### Version 0.5.0
 
 * Better Django backwards compatibility

--- a/jchart/config.py
+++ b/jchart/config.py
@@ -57,7 +57,7 @@ def DataSet(**kwargs):
                     'pointHoverBorderColor', 'pointHoverBorderWidth', 'pointStyle',
                     'data', 'label', 'backgroundColor', 'borderColor', 'borderWidth',
                     'hoverBackgroundColor', 'hoverBorderColor', 'hoverBorderWidth',
-                    'hoverRadius'}
+                    'hoverRadius', 'hidden'}
 
     assert_keys('DataSet', allowed_keys, kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
 
 setup(
     name='django-jchart',
-    version='0.4.2',
+    version='0.5.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
I wanted to hide a specific dataset inside my django-jchart but hidden wasn't supported.

> ValueError at / Use of illegal keyword arguments for DataSet: {'hidden'}

This tiny code enhancement enables this feature. After loading the page the dataset I wanted to be hidden was hidden and you have to click to show the chart.

Code exmple:

```
from jchart import Chart

class LineChart(Chart):
    chart_type = 'line'

    def get_datasets(self, **kwargs):
        return [{
            'label': "My Dataset",
            'data': [69, 30, 45, 60, 55],
            'hidden': True
        }]
 ```