### PR TITLE
fixed six import for django 3 compatibility

### DIFF
--- a/jchart/views/mixins.py
+++ b/jchart/views/mixins.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils import six
+import six
 
 # Django 1.5+ compat
 try:


### PR DESCRIPTION
Looks like six library is no longer in django.utils. This fix allows to use django-jchart with django 3.0.8.